### PR TITLE
Add installation method using package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,11 @@ cp plugin/* ~/.vim/plugin/
 
 and enjoy vim showing you results on save!
 
+Installation using vim-plug
+============================
+
+Add `Plug 'https://github.com/coala/coala-vim'` to your ~/.vimrc file and
+`:PlugInstall` to install coala-vim
+
+
 Demo: https://asciinema.org/a/3gxhsunm4cap876j2bdrkw705


### PR DESCRIPTION
Why? vim uses different package managers for easy installation. Installation methods for the main ones should exist.